### PR TITLE
backfill certs not in our database

### DIFF
--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -10,6 +10,13 @@ attrs==21.2.0
     # via pytest
 black==21.7b0
     # via -r pip-tools/dev-requirements.in
+boto3==1.18.25
+    # via -r pip-tools/../requirements.txt
+botocore==1.21.25
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   boto3
+    #   s3transfer
 cfenv==0.5.3
     # via -r pip-tools/../requirements.txt
 click==8.0.1
@@ -32,6 +39,11 @@ greenlet==1.1.1
     #   sqlalchemy
 iniconfig==1.1.1
     # via pytest
+jmespath==0.10.0
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   boto3
+    #   botocore
 marshmallow==3.13.0
     # via
     #   -r pip-tools/../requirements.txt
@@ -64,17 +76,26 @@ pytest==6.2.4
     #   pytest-watch
 pytest-watch==4.2.0
     # via -r pip-tools/dev-requirements.in
+python-dateutil==2.8.2
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   botocore
 python-dotenv==0.19.0
     # via
     #   -r pip-tools/../requirements.txt
     #   environs
 regex==2021.8.3
     # via black
+s3transfer==0.5.0
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   boto3
 six==1.16.0
     # via
     #   -r pip-tools/../requirements.txt
     #   furl
     #   orderedmultidict
+    #   python-dateutil
     #   sqlalchemy-utils
 sqlalchemy==1.4.23
     # via
@@ -88,6 +109,10 @@ tomli==1.2.1
     # via
     #   black
     #   pep517
+urllib3==1.26.6
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   botocore
 watchdog==2.1.3
     # via pytest-watch
 wheel==0.37.0

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -1,3 +1,4 @@
+boto3
 cfenv
 environs
 sqlalchemy

--- a/renewer/config.py
+++ b/renewer/config.py
@@ -36,6 +36,11 @@ class AppConfig(Config):
         self.CDN_BROKER_DATABASE_URI = normalize_db_url(cdn_db.credentials["uri"])
         alb_db = self.cf_env_parser.get_service(name="rds-domain-broker")
         self.DOMAIN_BROKER_DATABASE_URI = normalize_db_url(alb_db.credentials["uri"])
+        self.AWS_GOVCLOUD_REGION = self.env_parser("AWS_GOVCLOUD_REGION")
+        self.AWS_GOVCLOUD_ACCESS_KEY_ID = self.env_parser("AWS_GOVCLOUD_ACCESS_KEY_ID")
+        self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = self.env_parser(
+            "AWS_GOVCLOUD_SECRET_ACCESS_KEY"
+        )
 
 
 class LocalConfig(Config):
@@ -47,6 +52,9 @@ class LocalConfig(Config):
         self.DOMAIN_BROKER_DATABASE_URI = (
             "postgresql://localhost/local-development-domain"
         )
+        self.AWS_GOVCLOUD_REGION = "us-gov-west-1"
+        self.AWS_GOVCLOUD_ACCESS_KEY_ID = "ASIANOTAREALKEYGOV"
+        self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = "THIS_IS_A_FAKE_KEY_GOV"
 
 
 class DevelopmentConfig(AppConfig):

--- a/renewer/extensions.py
+++ b/renewer/extensions.py
@@ -1,4 +1,16 @@
+import boto3
+
 from renewer.config import config_from_env
 
 
 config = config_from_env()
+
+govcloud_session = boto3.Session(
+    region_name=config.AWS_GOVCLOUD_REGION,
+    aws_access_key_id=config.AWS_GOVCLOUD_ACCESS_KEY_ID,
+    aws_secret_access_key=config.AWS_GOVCLOUD_SECRET_ACCESS_KEY,
+)
+
+alb = govcloud_session.client("elbv2")
+iam_govcloud = govcloud_session.client("iam")
+iam_commercial = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,12 @@
 #
 #    ./dev update-requirements
 #
+boto3==1.18.25
+    # via -r pip-tools/requirements.in
+botocore==1.21.25
+    # via
+    #   boto3
+    #   s3transfer
 cfenv==0.5.3
     # via -r pip-tools/requirements.in
 environs==9.3.3
@@ -12,17 +18,27 @@ furl==2.1.2
     # via cfenv
 greenlet==1.1.1
     # via sqlalchemy
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
 marshmallow==3.13.0
     # via environs
 orderedmultidict==1.0.1
     # via furl
 psycopg2==2.9.1
     # via -r pip-tools/requirements.in
+python-dateutil==2.8.2
+    # via botocore
 python-dotenv==0.19.0
     # via environs
+s3transfer==0.5.0
+    # via boto3
 six==1.16.0
     # via
     #   furl
+    #   orderedmultidict
+    #   python-dateutil
     #   sqlalchemy-utils
 sqlalchemy==1.4.23
     # via
@@ -30,3 +46,5 @@ sqlalchemy==1.4.23
     #   sqlalchemy-utils
 sqlalchemy-utils==0.37.8
     # via -r pip-tools/requirements.in
+urllib3==1.26.6
+    # via botocore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 
 from tests.lib.database import clean_db
+from tests.lib.fake_alb import alb
+from tests.lib.fake_iam import iam_govcloud
 
 
 def pytest_configure(config):

--- a/tests/lib/fake_alb.py
+++ b/tests/lib/fake_alb.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+import pytest
+
+from renewer.extensions import alb as real_alb
+from tests.lib.fake_aws import FakeAWS
+
+
+class FakeALB(FakeAWS):
+    def expect_get_certificates_for_listener(
+        self, listener_arn, num_certificates=0, add_cert_arn=None
+    ):
+        certificates = [{"CertificateArn": "certificate-arn", "IsDefault": True}]
+        if add_cert_arn is not None:
+            certificates.append({"CertificateArn": add_cert_arn, "IsDefault": False})
+        for i in range(num_certificates):
+            certificates.append(
+                {"CertificateArn": f"certificate-arn-{i}", "IsDefault": False}
+            )
+        self.stubber.add_response(
+            "describe_listener_certificates",
+            {"Certificates": certificates},
+            {"ListenerArn": listener_arn},
+        )
+
+    def expect_add_certificate_to_listener(self, listener_arn, iam_cert_arn):
+        self.stubber.add_response(
+            "add_listener_certificates",
+            {
+                "Certificates": [
+                    {"CertificateArn": "arn:2", "IsDefault": True},
+                    {"CertificateArn": iam_cert_arn, "IsDefault": False},
+                ]
+            },
+            {
+                "ListenerArn": listener_arn,
+                "Certificates": [{"CertificateArn": iam_cert_arn}],
+            },
+        )
+
+    def expect_remove_certificate_from_listener(self, listener_arn, iam_cert_arn):
+        self.stubber.add_response(
+            "remove_listener_certificates",
+            {},
+            {
+                "ListenerArn": listener_arn,
+                "Certificates": [{"CertificateArn": iam_cert_arn}],
+            },
+        )
+
+    def expect_describe_alb(
+        self, alb_arn, returned_domain: str = "somedomain.cloud.test"
+    ):
+        self.stubber.add_response(
+            "describe_load_balancers",
+            {
+                "LoadBalancers": [
+                    {
+                        "LoadBalancerArn": "alb_arn",
+                        "DNSName": returned_domain,
+                        "CanonicalHostedZoneId": "ALBHOSTEDZONEID",
+                        "CreatedTime": datetime(2015, 1, 1),
+                        "LoadBalancerName": "string",
+                        "Scheme": "internet-facing",
+                        "VpcId": "string",
+                        "State": {"Code": "active", "Reason": "string"},
+                        "Type": "application",
+                        "AvailabilityZones": [
+                            {
+                                "ZoneName": "string",
+                                "SubnetId": "string",
+                                "LoadBalancerAddresses": [
+                                    {
+                                        "IpAddress": "string",
+                                        "AllocationId": "string",
+                                        "PrivateIPv4Address": "string",
+                                    }
+                                ],
+                            }
+                        ],
+                        "SecurityGroups": ["string"],
+                        "IpAddressType": "ipv4",
+                    }
+                ],
+                "NextMarker": "string",
+            },
+            {"LoadBalancerArns": [alb_arn]},
+        )
+
+
+@pytest.fixture(autouse=True)
+def alb():
+    with FakeALB.stubbing(real_alb) as alb_stubber:
+        yield alb_stubber

--- a/tests/lib/fake_aws.py
+++ b/tests/lib/fake_aws.py
@@ -1,0 +1,30 @@
+from contextlib import contextmanager
+
+from botocore import stub
+
+# How I would love to use Localstack or Moto instead.
+# Unfortunately, neither (in the OSS free version) supports Route53
+# and CloudFront.  So we've been reduced to using the "serviceable"
+# `boto3.stubber`
+
+
+class FakeAWS:
+    """ Base class for Fake* classes"""
+
+    @classmethod
+    @contextmanager
+    def stubbing(cls, real_resource):
+        with stub.Stubber(real_resource) as stubber:
+            fake_resource = cls(stubber)
+            yield fake_resource
+            fake_resource.assert_no_pending_responses()
+
+    def __init__(self, resource_stubber):
+        self.stubber = resource_stubber
+
+    def assert_no_pending_responses(self) -> None:
+        self.stubber.assert_no_pending_responses()
+
+    @property
+    def ANY(self):
+        return stub.ANY

--- a/tests/lib/fake_iam.py
+++ b/tests/lib/fake_iam.py
@@ -1,0 +1,98 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from renewer.extensions import iam_commercial as real_iam_c
+from renewer.extensions import iam_govcloud as real_iam_g
+from tests.lib.fake_aws import FakeAWS
+
+
+class FakeIAM(FakeAWS):
+    def expect_upload_server_certificate(
+        self, name: str, cert: str, private_key: str, chain: str, path: str
+    ):
+        now = datetime.now(timezone.utc)
+        three_months_from_now = now + timedelta(90)
+        method = "upload_server_certificate"
+        request = {
+            "Path": path,
+            "ServerCertificateName": name,
+            "CertificateBody": cert,
+            "PrivateKey": private_key,
+            "CertificateChain": chain,
+        }
+        response = {
+            "ServerCertificateMetadata": {
+                "ServerCertificateId": "FAKE_CERT_ID_XXXXXXXX",
+                "Path": path,
+                "ServerCertificateName": name,
+                "Arn": f"arn:aws:iam::000000000000:server-certificate{path}{name}",
+                "UploadDate": now,
+                "Expiration": three_months_from_now,
+            }
+        }
+        self.stubber.add_response(method, response, request)
+
+    def expect_upload_server_certificate_raising_duplicate(
+        self, name: str, cert: str, private_key: str, chain: str, path: str
+    ):
+        self.stubber.add_client_error(
+            "upload_server_certificate",
+            service_error_code="EntityAlreadyExistsException",
+            service_message="already got one",
+            expected_params={
+                "Path": path,
+                "ServerCertificateName": name,
+                "CertificateBody": cert,
+                "PrivateKey": private_key,
+                "CertificateChain": chain,
+            },
+        )
+
+    def expects_delete_server_certificate(self, name: str):
+        self.stubber.add_response(
+            "delete_server_certificate", {}, {"ServerCertificateName": name}
+        )
+
+    def expects_delete_server_certificate_returning_no_such_entity(self, name: str):
+        self.stubber.add_client_error(
+            "delete_server_certificate",
+            service_error_code="NoSuchEntity",
+            service_message="'Ain't there.",
+            http_status_code=404,
+            expected_params={"ServerCertificateName": name},
+        )
+
+    def expect_get_server_certificate(self, name, expiration, path=None):
+        if path is None:
+            path = "/"
+        response = {
+            "ServerCertificate": {
+                "ServerCertificateMetadata": {
+                    "Path": path,
+                    "ServerCertificateName": name,
+                    "ServerCertificateId": "this-needs-to-be-sixteen-digits",
+                    "Arn": f"arn:aws:iam:123456:{path}{name}",
+                    "UploadDate": "2021-08-05T16:49:16Z",
+                    "Expiration": expiration,
+                },
+                "CertificateBody": "string",
+                "CertificateChain": "string",
+                "Tags": [{"Key": "string", "Value": "string"}],
+            }
+        }
+        self.stubber.add_response(
+            "get_server_certificate", response, {"ServerCertificateName": name}
+        )
+
+
+@pytest.fixture(autouse=True)
+def iam_commercial():
+    with FakeIAM.stubbing(real_iam_c) as iam_stubber:
+        yield iam_stubber
+
+
+@pytest.fixture(autouse=True)
+def iam_govcloud():
+    with FakeIAM.stubbing(real_iam_g) as iam_stubber:
+        yield iam_stubber

--- a/tests/unit/test_alb_db.py
+++ b/tests/unit/test_alb_db.py
@@ -90,11 +90,9 @@ def test_need_renewal_basic(clean_db):
     doesnt_need_renewal_route.instance_id = "dont-renew-me"
     doesnt_need_renewal_cert = DomainCertificate()
     doesnt_need_renewal_cert.route = doesnt_need_renewal_route
-    doesnt_need_renewal_cert.id = 10
     doesnt_need_renewal_cert.expires = datetime.now() + timedelta(days=31)
     doesnt_need_renewal_old_cert = DomainCertificate()
     doesnt_need_renewal_old_cert.route = doesnt_need_renewal_route
-    doesnt_need_renewal_old_cert.id = 11
     doesnt_need_renewal_old_cert.expires = datetime.now() - timedelta(days=31)
 
     # make a route that needs renewal
@@ -103,11 +101,9 @@ def test_need_renewal_basic(clean_db):
     needs_renewal_route.instance_id = "renew-me"
     needs_renewal_cert = DomainCertificate()
     needs_renewal_cert.route = needs_renewal_route
-    needs_renewal_cert.id = 0
     needs_renewal_cert.expires = datetime.now() + timedelta(days=10)
     needs_renewal_old_cert = DomainCertificate()
     needs_renewal_old_cert.route = needs_renewal_route
-    needs_renewal_old_cert.id = 1
     needs_renewal_old_cert.expires = datetime.now() - timedelta(days=10)
 
     # commit them (this probably isn't necessary, but helps ensure we made them correctly)
@@ -122,3 +118,88 @@ def test_need_renewal_basic(clean_db):
     # check if they need renewal
     assert needs_renewal_route.needs_renewal
     assert not doesnt_need_renewal_route.needs_renewal
+
+
+def test_backport_from_manual_renewal(clean_db, alb, iam_govcloud):
+    # make a route
+    proxy = DomainAlbProxy()
+    proxy.alb_arn = "arn:aws:alb:123"
+    proxy.alb_dns_name = "example.com"
+    proxy.listener_arn = "arn:aws:listener:123"
+    route = DomainRoute()
+    route.state = "provisioned"
+    route.instance_id = "renew-me"
+    route.alb_proxy_arn = "arn:aws:alb:123"
+    old_cert = DomainCertificate()
+    old_cert.route = route
+    old_cert.expires = datetime(year=2021, month=2, day=1, hour=0, minute=0, second=0)
+    old_cert.arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
+    clean_db.add(proxy)
+    clean_db.add(route)
+    clean_db.add(old_cert)
+    clean_db.commit()
+
+    # get the certs for the alb
+    alb.expect_get_certificates_for_listener(
+        "arn:aws:listener:123",
+        7,
+        "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-03-12_12-34-12",
+    )
+    iam_govcloud.expect_get_server_certificate(
+        "cf-domains-renew-me-2021-03-12_12-34-12", "2021-03-12T12:34:12Z"
+    )
+
+    cert = route.backport_manual_certs()
+    clean_db.add(cert)
+    clean_db.commit()
+
+    clean_db.expunge_all()
+    route = clean_db.query(DomainRoute).filter_by(instance_id="renew-me").first()
+    cert = route.certificates[0]
+    assert (
+        cert.arn
+        == "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-03-12_12-34-12"
+    )
+    assert cert.expires is not None
+    assert cert.name == "cf-domains-renew-me-2021-03-12_12-34-12"
+
+
+def test_backport_from_manual_renewal_ignores_existing(clean_db, alb, iam_govcloud):
+    # make a route
+    proxy = DomainAlbProxy()
+    proxy.alb_arn = "arn:aws:alb:123"
+    proxy.alb_dns_name = "example.com"
+    proxy.listener_arn = "arn:aws:listener:123"
+    route = DomainRoute()
+    route.state = "provisioned"
+    route.instance_id = "renew-me"
+    route.alb_proxy_arn = "arn:aws:alb:123"
+    old_cert = DomainCertificate()
+    old_cert.route = route
+    old_cert.expires = datetime(year=2021, month=2, day=1, hour=0, minute=0, second=0)
+    old_cert.arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
+    old_cert.name = "cf-domains-renew-me-2021-01-01_12-34-56"
+    clean_db.add(proxy)
+    clean_db.add(route)
+    clean_db.add(old_cert)
+    clean_db.commit()
+
+    # get the certs for the alb
+    alb.expect_get_certificates_for_listener(
+        "arn:aws:listener:123",
+        7,
+        "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56",
+    )
+
+    cert = route.backport_manual_certs()
+    assert cert is None
+
+    clean_db.expunge_all()
+    route = clean_db.query(DomainRoute).filter_by(instance_id="renew-me").first()
+    cert = route.certificates[0]
+    assert (
+        cert.arn
+        == "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
+    )
+    assert cert.expires is not None
+    assert cert.name == "cf-domains-renew-me-2021-01-01_12-34-56"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -69,6 +69,9 @@ def mocked_env(vcap_application, vcap_services, monkeypatch):
     monkeypatch.setenv("VCAP_APPLICATION", vcap_application)
     monkeypatch.setenv("VCAP_SERVICES", vcap_services)
     monkeypatch.setenv("ENV", "local")
+    monkeypatch.setenv("AWS_GOVCLOUD_REGION", "us-gov-west-1")
+    monkeypatch.setenv("AWS_GOVCLOUD_ACCESS_KEY_ID", "ASIANOTAREALKEYGOV")
+    monkeypatch.setenv("AWS_GOVCLOUD_SECRET_ACCESS_KEY", "NOT_A_REAL_SECRET_KEY_GOV")
 
 
 @pytest.mark.parametrize("env", ["local", "development", "staging", "production"])
@@ -85,3 +88,6 @@ def test_config_gets_credentials(env, monkeypatch, mocked_env):
     assert config.CDN_BROKER_DATABASE_URI == "postgresql://cdn-db-uri"
     assert config.DOMAIN_BROKER_DATABASE_URI == "postgresql://alb-db-uri"
     assert config.RENEW_BEFORE_DAYS == 30
+    assert config.AWS_GOVCLOUD_REGION == "us-gov-west-1"
+    assert config.AWS_GOVCLOUD_ACCESS_KEY_ID == "ASIANOTAREALKEYGOV"
+    assert config.AWS_GOVCLOUD_SECRET_ACCESS_KEY == "NOT_A_REAL_SECRET_KEY_GOV"


### PR DESCRIPTION
## Changes proposed in this pull request:

- backfill certs not in our database. This will allow us to treat all our instances the same when we go to renew


## Security considerations

None