### PR TITLE
drop challtestsrv since we won't be using dns-01 challenges

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -35,7 +35,6 @@ RUN apt update \
 # Install Fake Pebble LE server
 COPY --from=letsencrypt/pebble /usr/bin/pebble /usr/bin/pebble
 COPY --from=letsencrypt/pebble /test/ /test/
-COPY --from=letsencrypt/pebble-challtestsrv /usr/bin/pebble-challtestsrv /usr/bin/pebble-challtestsrv
 
 RUN cp /test/certs/pebble.minica.pem /usr/local/share/ca-certificates/pebble.crt \
  && update-ca-certificates

--- a/docker/start-servers.sh
+++ b/docker/start-servers.sh
@@ -26,13 +26,3 @@ if ! pgrep -x pebble > /dev/null; then
       > "$LOGS/pebble.log" 2>&1 &
   )
 fi
-
-if ! pgrep -x pebble-challtestsrv > /dev/null; then
-  echo "Starting Pebble Challenge Test Server"
-  (
-    cd /app
-    pebble-challtestsrv \
-      > "$LOGS/pebble-challtestsrv.log" 2>&1 &
-  )
-fi
-

--- a/docker/stop-servers.sh
+++ b/docker/stop-servers.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
 pkill -x pebble
-pkill -x pebble-challtestsrv
 pg_ctl stop 


### PR DESCRIPTION
## Changes proposed in this pull request:

- drop challtestsrv since we won't be using dns-01 challenges (challtestsrv is just a dns server for integration testing Lets Encrypt)

## Security considerations

None