### PR TITLE
Split encryption keys by database

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -113,6 +113,9 @@ jobs:
     params:
       <<: *cf-creds-dev
       <<: *upgrade-schema-vars
+      environment_variables:
+        CDN_DATABASE_ENCRYPTION_KEY: ((dev-cdn-database-encryption-key))
+        DOMAIN_DATABASE_ENCRYPTION_KEY: ((dev-domain-database-encryption-key))
   - put: cf-dev
     params:
       path: src
@@ -125,6 +128,8 @@ jobs:
         AWS_GOVCLOUD_SECRET_ACCESS_KEY: ((dev-aws-govcloud-secret-access-key))
         AWS_GOVCLOUD_ACCESS_KEY_ID: ((dev-aws-govcloud-access-key-id))
         LETS_ENCRYPT_REGISTRATION_EMAIL: ((lets_encrypt_registration_email))
+        CDN_DATABASE_ENCRYPTION_KEY: ((dev-cdn-database-encryption-key))
+        DOMAIN_DATABASE_ENCRYPTION_KEY: ((dev-domain-database-encryption-key))
   on_failure:
     put: slack
     params:
@@ -168,6 +173,9 @@ jobs:
     params:
       <<: *cf-creds-staging
       <<: *upgrade-schema-vars
+      environment_variables:
+        CDN_DATABASE_ENCRYPTION_KEY: ((staging-cdn-database-encryption-key))
+        DOMAIN_DATABASE_ENCRYPTION_KEY: ((staging-domain-database-encryption-key))
   - put: cf-staging
     params:
       path: src
@@ -180,6 +188,8 @@ jobs:
         AWS_GOVCLOUD_SECRET_ACCESS_KEY: ((staging-aws-govcloud-secret-access-key))
         AWS_GOVCLOUD_ACCESS_KEY_ID: ((staging-aws-govcloud-access-key-id))
         LETS_ENCRYPT_REGISTRATION_EMAIL: ((lets_encrypt_registration_email))
+        CDN_DATABASE_ENCRYPTION_KEY: ((staging-cdn-database-encryption-key))
+        DOMAIN_DATABASE_ENCRYPTION_KEY: ((staging-domain-database-encryption-key))
   on_failure:
     put: slack
     params:
@@ -223,6 +233,9 @@ jobs:
     params:
       <<: *cf-creds-production
       <<: *upgrade-schema-vars
+      environment_variables:
+        CDN_DATABASE_ENCRYPTION_KEY: ((production-cdn-database-encryption-key))
+        DOMAIN_DATABASE_ENCRYPTION_KEY: ((production-domain-database-encryption-key))
   - put: cf-production
     params:
       path: src
@@ -235,6 +248,8 @@ jobs:
         AWS_GOVCLOUD_SECRET_ACCESS_KEY: ((production-aws-govcloud-secret-access-key))
         AWS_GOVCLOUD_ACCESS_KEY_ID: ((production-aws-govcloud-access-key-id))
         LETS_ENCRYPT_REGISTRATION_EMAIL: ((lets_encrypt_registration_email))
+        CDN_DATABASE_ENCRYPTION_KEY: ((production-cdn-database-encryption-key))
+        DOMAIN_DATABASE_ENCRYPTION_KEY: ((production-domain-database-encryption-key))
 
   on_failure:
     put: slack

--- a/renewer/cdn_models.py
+++ b/renewer/cdn_models.py
@@ -30,7 +30,7 @@ CdnBase = declarative.declarative_base(metadata=metadata)
 
 
 def db_encryption_key():
-    return config.DATABASE_ENCRYPTION_KEY
+    return config.CDN_DATABASE_ENCRYPTION_KEY
 
 
 class CdnUserData(CdnBase):

--- a/renewer/config.py
+++ b/renewer/config.py
@@ -57,7 +57,8 @@ class AppConfig(Config):
         self.LETS_ENCRYPT_REGISTRATION_EMAIL = self.env_parser(
             "LETS_ENCRYPT_REGISTRATION_EMAIL"
         )
-        self.DATABASE_ENCRYPTION_KEY = self.env_parser("DATABASE_ENCRYPTION_KEY")
+        self.CDN_DATABASE_ENCRYPTION_KEY = self.env_parser("CDN_DATABASE_ENCRYPTION_KEY")
+        self.DOMAIN_DATABASE_ENCRYPTION_KEY = self.env_parser("DOMAIN_DATABASE_ENCRYPTION_KEY")
 
 
 class LocalConfig(Config):
@@ -80,7 +81,8 @@ class LocalConfig(Config):
 
         self.ACME_DIRECTORY = "https://localhost:14000/dir"
         self.LETS_ENCRYPT_REGISTRATION_EMAIL = "ops@example.com"
-        self.DATABASE_ENCRYPTION_KEY = "feedabee"
+        self.DOMAIN_DATABASE_ENCRYPTION_KEY = "feedabee"
+        self.CDN_DATABASE_ENCRYPTION_KEY = "changeme"
 
 
 class UpgradeSchemaConfig(Config):
@@ -95,4 +97,5 @@ class UpgradeSchemaConfig(Config):
         self.AWS_GOVCLOUD_REGION = "none"
         self.AWS_GOVCLOUD_ACCESS_KEY_ID = None
         self.AWS_GOVCLOUD_SECRET_ACCESS_KEY = None
-        self.DATABASE_ENCRYPTION_KEY = self.env_parser("DATABASE_ENCRYPTION_KEY")
+        self.CDN_DATABASE_ENCRYPTION_KEY = self.env_parser("CDN_DATABASE_ENCRYPTION_KEY")
+        self.DOMAIN_DATABASE_ENCRYPTION_KEY = self.env_parser("DOMAIN_DATABASE_ENCRYPTION_KEY")

--- a/renewer/domain_models.py
+++ b/renewer/domain_models.py
@@ -30,7 +30,7 @@ DomainBase = declarative.declarative_base(metadata=metadata)
 
 
 def db_encryption_key():
-    return config.DATABASE_ENCRYPTION_KEY
+    return config.DOMAIN_DATABASE_ENCRYPTION_KEY
 
 
 def find_active_instances(session):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -86,7 +86,8 @@ def mocked_env(vcap_application, vcap_services, monkeypatch):
     monkeypatch.setenv("VCAP_APPLICATION", vcap_application)
     monkeypatch.setenv("VCAP_SERVICES", vcap_services)
     monkeypatch.setenv("ENV", "local")
-    monkeypatch.setenv("DATABASE_ENCRYPTION_KEY", "CHANGEME")
+    monkeypatch.setenv("CDN_DATABASE_ENCRYPTION_KEY", "CHANGEME")
+    monkeypatch.setenv("DOMAIN_DATABASE_ENCRYPTION_KEY", "CHANGEME")
     monkeypatch.setenv("LETS_ENCRYPT_REGISTRATION_EMAIL", "me@example.com")
     monkeypatch.setenv("AWS_GOVCLOUD_REGION", "us-gov-west-1")
     monkeypatch.setenv("AWS_GOVCLOUD_ACCESS_KEY_ID", "ASIANOTAREALKEYGOV")
@@ -114,7 +115,8 @@ def test_config_gets_credentials(env, monkeypatch, mocked_env):
     assert config.REDIS_PORT == "my-redis-port"
     assert config.REDIS_PASSWORD == "my-redis-password"
     assert config.LETS_ENCRYPT_REGISTRATION_EMAIL == "me@example.com"
-    assert config.DATABASE_ENCRYPTION_KEY is not None
+    assert config.CDN_DATABASE_ENCRYPTION_KEY is not None
+    assert config.DOMAIN_DATABASE_ENCRYPTION_KEY is not None
 
     # import these here, so it's clear we're just importing them for this test
     import renewer.extensions
@@ -175,13 +177,15 @@ def test_upgrade_config(monkeypatch, vcap_application, vcap_services):
     monkeypatch.setenv("VCAP_APPLICATION", vcap_application)
     monkeypatch.setenv("VCAP_SERVICES", vcap_services)
     monkeypatch.setenv("ENV", "upgrade-schema")
-    monkeypatch.setenv("DATABASE_ENCRYPTION_KEY", "CHANGEME")
+    monkeypatch.setenv("CDN_DATABASE_ENCRYPTION_KEY", "CHANGEME")
+    monkeypatch.setenv("DOMAIN_DATABASE_ENCRYPTION_KEY", "CHANGEME")
     config = config_from_env()
 
     # make assertions about the config
     assert config.CDN_BROKER_DATABASE_URI == "postgresql://cdn-db-uri"
     assert config.DOMAIN_BROKER_DATABASE_URI == "postgresql://alb-db-uri"
-    assert config.DATABASE_ENCRYPTION_KEY is not None
+    assert config.CDN_DATABASE_ENCRYPTION_KEY is not None
+    assert config.DOMAIN_DATABASE_ENCRYPTION_KEY is not None
 
     raised = None
     try:


### PR DESCRIPTION

## Changes proposed in this pull request:

- use unique keys per database to limit blast radius
- set keys in pipeline to fix build


## Security considerations

using unique keys for each database reduces impact of leaked keys