### PR TITLE
Report solved challenges

### DIFF
--- a/docker/start-servers.sh
+++ b/docker/start-servers.sh
@@ -19,7 +19,7 @@ if ! pgrep -x pebble > /dev/null; then
   echo "Starting Pebble"
   (
     cd /
-    PEBBLE_WFE_NONCEREJECT=0 pebble \
+    PEBBLE_VA_ALWAYS_VALID=1 PEBBLE_WFE_NONCEREJECT=0 pebble \
       -config="/test/config/pebble-config.json" \
       -dnsserver="127.0.0.1:8053" \
       -strict \

--- a/renewer/config.py
+++ b/renewer/config.py
@@ -73,6 +73,7 @@ class AppConfig(Config):
         self.DOMAIN_DATABASE_ENCRYPTION_KEY = self.env_parser(
             "DOMAIN_DATABASE_ENCRYPTION_KEY"
         )
+        self.S3_PROPAGATION_TIME = self.env_parser.int("S3_PROPAGATION_TIME", 10)
 
 
 class LocalConfig(Config):
@@ -102,6 +103,7 @@ class LocalConfig(Config):
         self.LETS_ENCRYPT_REGISTRATION_EMAIL = "ops@example.com"
         self.DOMAIN_DATABASE_ENCRYPTION_KEY = "feedabee"
         self.CDN_DATABASE_ENCRYPTION_KEY = "changeme"
+        self.S3_PROPAGATION_TIME = 0
 
 
 class UpgradeSchemaConfig(Config):

--- a/renewer/tasks/letsencrypt.py
+++ b/renewer/tasks/letsencrypt.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import time
 from typing import Type, Union
 
 import josepy
@@ -238,8 +237,6 @@ def answer_challenges(session, operation_id: int, instance_type: RouteType):
 
     if not unanswered:
         return
-
-    # todo: add sleep here
 
     account_key = serialization.load_pem_private_key(
         acme_user.private_key_pem.encode(), password=None, backend=default_backend()

--- a/renewer/tasks/s3.py
+++ b/renewer/tasks/s3.py
@@ -1,3 +1,4 @@
+import time
 from typing import Type, Union
 
 from renewer.aws import s3_commercial, s3_govcloud
@@ -34,3 +35,5 @@ def upload_challenge_files(session, operation_id, route_type):
                 Key=challenge.validation_path,
                 ServerSideEncryption="AES256",
             )
+    # sleep to make sure the file will be in S3 when we want it
+    time.sleep(config.S3_PROPAGATION_TIME)

--- a/tests/integration/test_alb_renewal.py
+++ b/tests/integration/test_alb_renewal.py
@@ -106,6 +106,11 @@ def test_uploads_challenge_files(
 
 
 def test_answer_challenges(clean_db, alb_route: DomainRoute, immediate_huey):
+    # this tests that we call answer challenges correctly.
+    # We have pebble set to not validate challenges, though, because 
+    # we don't have a meaningful way to validate them, so our test is 
+    # pretty much limited to happy-path testing and assuming that we got 
+    # the s3 stuff done correctly. 
     instance_id = alb_route.instance_id
     operation = alb_route.create_renewal_operation()
     clean_db.add(alb_route)
@@ -122,7 +127,7 @@ def test_answer_challenges(clean_db, alb_route: DomainRoute, immediate_huey):
     # function we're actually testing
     letsencrypt.answer_challenges(operation_id, alb_route.route_type)
     clean_db.expunge_all()
-
+    
     operation = clean_db.query(DomainOperation).get(operation_id)
     certificate = operation.certificate
     assert all([c.answered for c in certificate.challenges])

--- a/tests/lib/fake_s3.py
+++ b/tests/lib/fake_s3.py
@@ -15,10 +15,7 @@ class FakeS3(FakeAWS):
             "Body": object_body_bytes,
             "ServerSideEncryption": "AES256",
         }
-        response = {
-            "ETag": "whatsanetag",
-            "ServerSideEncryption": "AES256",
-        }
+        response = {"ETag": "whatsanetag", "ServerSideEncryption": "AES256"}
         self.stubber.add_response("put_object", response, request)
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -97,6 +97,7 @@ def mocked_env(vcap_application, vcap_services, monkeypatch):
     monkeypatch.setenv("AWS_GOVCLOUD_ACCESS_KEY_ID", "ASIANOTAREALKEYGOV")
     monkeypatch.setenv("AWS_GOVCLOUD_SECRET_ACCESS_KEY", "NOT_A_REAL_SECRET_KEY_GOV")
     monkeypatch.setenv("GOVCLOUD_BUCKET", "fake-govcloud-bucket")
+    monkeypatch.setenv("S3_PROPAGATION_TIME", "5")
 
 
 @pytest.mark.parametrize("env", ["local", "development", "staging", "production"])
@@ -127,6 +128,7 @@ def test_config_gets_credentials(env, monkeypatch, mocked_env):
     assert config.LETS_ENCRYPT_REGISTRATION_EMAIL == "me@example.com"
     assert config.CDN_DATABASE_ENCRYPTION_KEY is not None
     assert config.DOMAIN_DATABASE_ENCRYPTION_KEY is not None
+    assert config.S3_PROPAGATION_TIME == 5
 
     # import these here, so it's clear we're just importing them for this test
     import renewer.extensions


### PR DESCRIPTION
## Changes proposed in this pull request:

- tell Lets Encrypt to validate our challenges 
- add some time after s3 and before talking to LE

(also noted in a comment) 
Note that we're skipping testing a very big chunk here: we tell pebble (the test ACME server) not to validate challenges. I can't really see a way around this, since we don't want to actually post to s3 buckets and have pebble reach out to them during tests. 
The upshot is that we're trusting that we're doing the right thing when we put our challenge responses into S3. If not, we'll have to iterate on this somewhat blindly in the future


## Security considerations

None