### PR TITLE
Add function to rotate CDN certs

### DIFF
--- a/renewer/aws.py
+++ b/renewer/aws.py
@@ -14,6 +14,7 @@ govcloud_session = boto3.Session(
 )
 
 alb = govcloud_session.client("elbv2")
+cloudfront = commercial_session.client("cloudfront")
 iam_govcloud = govcloud_session.client("iam")
 iam_commercial = commercial_session.client("iam")
 s3_govcloud = govcloud_session.client("s3")

--- a/renewer/tasks/cdn.py
+++ b/renewer/tasks/cdn.py
@@ -1,0 +1,23 @@
+from renewer import huey
+from renewer.aws import cloudfront
+from renewer.cdn_models import CdnOperation
+
+
+@huey.retriable_task
+def associate_certificate(session, operation_id):
+    operation = session.query(CdnOperation).get(operation_id)
+    certificate = operation.certificate
+    route = operation.route
+    config = cloudfront.get_distribution_config(Id=route.dist_id)
+    config["DistributionConfig"]["ViewerCertificate"][
+        "IAMCertificateId"
+    ] = certificate.iam_server_certificate_id
+    cloudfront.update_distribution(
+        DistributionConfig=config["DistributionConfig"],
+        Id=route.dist_id,
+        IfMatch=config["ETag"],
+    )
+    certificate.route = route
+
+    session.add(certificate)
+    session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from tests.lib.alb_fixtures import alb_route, proxy
 from tests.lib.cdn_fixtures import cdn_route
 from tests.lib.database import clean_db
 from tests.lib.fake_alb import alb
+from tests.lib.fake_cloudfront import cloudfront
 from tests.lib.fake_iam import iam_commercial, iam_govcloud
 from tests.lib.fake_s3 import s3_commercial, s3_govcloud
 from tests.lib.tasks import tasks, immediate_huey

--- a/tests/lib/cdn_fixtures.py
+++ b/tests/lib/cdn_fixtures.py
@@ -9,6 +9,7 @@ def cdn_route(clean_db):
     route.instance_id = "fixture-route"
     route.state = "provisioned"
     route.domain_external = "example.com,www.example.com"
+    route.dist_id = "fakedistid"
     clean_db.add(route)
     clean_db.commit()
     return route

--- a/tests/lib/fake_cloudfront.py
+++ b/tests/lib/fake_cloudfront.py
@@ -1,0 +1,320 @@
+from datetime import datetime
+from typing import Any, Dict, List
+
+import pytest
+
+from renewer.aws import cloudfront as real_cloudfront
+from tests.lib.fake_aws import FakeAWS
+
+
+class FakeCloudFront(FakeAWS):
+    def expect_get_distribution_config(
+        self,
+        caller_reference: str,
+        domains: List[str],
+        certificate_id: str,
+        origin_hostname: str,
+        origin_path: str,
+        distribution_id: str,
+        forward_cookie_policy: str = "all",
+        forwarded_cookies: list = None,
+        forwarded_headers: list = None,
+        origin_protocol_policy: str = "https-only",
+        bucket_prefix: str = "",
+        custom_error_responses: str = None,
+        include_le_bucket: bool = False,
+        include_log_bucket: bool = True,
+    ):
+        if custom_error_responses is None:
+            custom_error_responses = {"Quantity": 0}
+        if forwarded_headers is None:
+            forwarded_headers = ["HOST"]
+        self.etag = str(datetime.now().timestamp())
+        self.stubber.add_response(
+            "get_distribution_config",
+            {
+                "DistributionConfig": self._distribution_config(
+                    caller_reference,
+                    domains,
+                    certificate_id,
+                    origin_hostname,
+                    origin_path,
+                    forward_cookie_policy=forward_cookie_policy,
+                    forwarded_cookies=forwarded_cookies,
+                    forwarded_headers=forwarded_headers,
+                    origin_protocol_policy=origin_protocol_policy,
+                    bucket_prefix=bucket_prefix,
+                    custom_error_responses=custom_error_responses,
+                    include_le_bucket=include_le_bucket,
+                    include_log_bucket=include_log_bucket,
+                ),
+                "ETag": self.etag,
+            },
+            {"Id": distribution_id},
+        )
+
+    def expect_update_distribution(
+        self,
+        caller_reference: str,
+        domains: List[str],
+        certificate_id: str,
+        origin_hostname: str,
+        origin_path: str,
+        distribution_id: str,
+        distribution_hostname: str,
+        forward_cookie_policy: str = "all",
+        forwarded_cookies: list = None,
+        forwarded_headers: list = None,
+        origin_protocol_policy: str = "https-only",
+        bucket_prefix: str = "",
+        custom_error_responses: dict = None,
+    ):
+        if custom_error_responses is None:
+            custom_error_responses = {"Quantity": 0}
+        if forwarded_headers is None:
+            forwarded_headers = ["HOST"]
+        self.stubber.add_response(
+            "update_distribution",
+            self._distribution_response(
+                caller_reference,
+                domains,
+                certificate_id,
+                origin_hostname,
+                origin_path,
+                distribution_id,
+                distribution_hostname,
+                forward_cookie_policy=forward_cookie_policy,
+                forwarded_cookies=forwarded_cookies,
+                forwarded_headers=forwarded_headers,
+                origin_protocol_policy=origin_protocol_policy,
+                bucket_prefix=bucket_prefix,
+                custom_error_responses=custom_error_responses,
+            ),
+            {
+                "DistributionConfig": self._distribution_config(
+                    caller_reference,
+                    domains,
+                    certificate_id,
+                    origin_hostname,
+                    origin_path,
+                    forward_cookie_policy=forward_cookie_policy,
+                    forwarded_cookies=forwarded_cookies,
+                    forwarded_headers=forwarded_headers,
+                    origin_protocol_policy=origin_protocol_policy,
+                    bucket_prefix=bucket_prefix,
+                    custom_error_responses=custom_error_responses,
+                ),
+                "Id": distribution_id,
+                "IfMatch": self.etag,
+            },
+        )
+
+    def _distribution_config(
+        self,
+        caller_reference: str,
+        domains: List[str],
+        iam_server_certificate_id: str,
+        origin_hostname: str,
+        origin_path: str,
+        enabled: bool = True,
+        forward_cookie_policy: str = "all",
+        forwarded_cookies: list = None,
+        forwarded_headers: list = None,
+        origin_protocol_policy: str = "https-only",
+        bucket_prefix: str = "",
+        custom_error_responses: dict = None,
+        include_le_bucket: bool = False,
+        include_log_bucket: bool = True,
+    ) -> Dict[str, Any]:
+        if forwarded_headers is None:
+            forwarded_headers = ["HOST"]
+        cookies = {"Forward": forward_cookie_policy}
+        if forward_cookie_policy == "whitelist":
+            cookies["WhitelistedNames"] = {
+                "Quantity": len(forwarded_cookies),
+                "Items": forwarded_cookies,
+            }
+        response = {
+            "CallerReference": caller_reference,
+            "Aliases": {"Quantity": len(domains), "Items": domains},
+            "DefaultRootObject": "",
+            "Origins": {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "Id": "default-origin",
+                        "DomainName": origin_hostname,
+                        "OriginPath": origin_path,
+                        "CustomOriginConfig": {
+                            "HTTPPort": 80,
+                            "HTTPSPort": 443,
+                            "OriginProtocolPolicy": origin_protocol_policy,
+                            "OriginSslProtocols": {"Quantity": 1, "Items": ["TLSv1.2"]},
+                            "OriginReadTimeout": 30,
+                            "OriginKeepaliveTimeout": 5,
+                        },
+                    }
+                ],
+            },
+            "OriginGroups": {"Quantity": 0},
+            "DefaultCacheBehavior": {
+                "TargetOriginId": "default-origin",
+                "ForwardedValues": {
+                    "QueryString": True,
+                    "Cookies": cookies,
+                    "Headers": {
+                        "Quantity": len(forwarded_headers),
+                        "Items": forwarded_headers,
+                    },
+                    "QueryStringCacheKeys": {"Quantity": 0},
+                },
+                "TrustedSigners": {"Enabled": False, "Quantity": 0},
+                "ViewerProtocolPolicy": "redirect-to-https",
+                "MinTTL": 0,
+                "AllowedMethods": {
+                    "Quantity": 7,
+                    "Items": [
+                        "GET",
+                        "HEAD",
+                        "POST",
+                        "PUT",
+                        "PATCH",
+                        "OPTIONS",
+                        "DELETE",
+                    ],
+                    "CachedMethods": {"Quantity": 2, "Items": ["GET", "HEAD"]},
+                },
+                "SmoothStreaming": False,
+                "DefaultTTL": 86400,
+                "MaxTTL": 31536000,
+                "Compress": False,
+                "LambdaFunctionAssociations": {"Quantity": 0},
+            },
+            "CacheBehaviors": {"Quantity": 0},
+            "CustomErrorResponses": custom_error_responses,
+            "Comment": "external domain service https://cloud-gov/external-domain-broker",
+            "PriceClass": "PriceClass_100",
+            "Enabled": enabled,
+            "ViewerCertificate": {
+                "CloudFrontDefaultCertificate": False,
+                "IAMCertificateId": iam_server_certificate_id,
+                "SSLSupportMethod": "sni-only",
+                "MinimumProtocolVersion": "TLSv1.2_2018",
+            },
+            "IsIPV6Enabled": True,
+        }
+        if include_le_bucket:
+            response["Origins"]["Quantity"] += 1
+            response["Origins"]["Items"].append(
+                {
+                    "Id": "s3-cdn-broker-le-test-some-other-stuff",
+                    "DomainName": "cdn-broker-le-test.s3.amazonaws.com",
+                    "OriginPath": "",
+                    "CustomHeaders": {"Quantity": 0},
+                    "S3OriginConfig": {"OriginAccessIdentity": ""},
+                }
+            )
+            response["CacheBehaviors"] = {
+                "Quantity": 1,
+                "Items": [
+                    {
+                        "PathPattern": "/.well-known/acme-challenge/*",
+                        "TargetOriginId": "s3-cdn-broker-le-test-some-other-stuff",
+                        "ForwardedValues": {
+                            "QueryString": False,
+                            "Cookies": {"Forward": "none"},
+                            "Headers": {"Quantity": 0},
+                            "QueryStringCacheKeys": {"Quantity": 0},
+                        },
+                        "TrustedSigners": {"Enabled": False, "Quantity": 0},
+                        "ViewerProtocolPolicy": "allow-all",
+                        "MinTTL": 0,
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": ["HEAD", "GET"],
+                            "CachedMethods": {"Quantity": 2, "Items": ["HEAD", "GET"]},
+                        },
+                        "SmoothStreaming": False,
+                        "DefaultTTL": 86400,
+                        "MaxTTL": 31536000,
+                        "Compress": False,
+                        "LambdaFunctionAssociations": {"Quantity": 0},
+                        "FieldLevelEncryptionId": "",
+                    }
+                ],
+            }
+        if include_log_bucket:
+            response["Logging"] = {
+                "Enabled": True,
+                "IncludeCookies": False,
+                "Bucket": "mybucket.s3.amazonaws.com",
+                "Prefix": bucket_prefix,
+            }
+        else:
+            response["Logging"] = {
+                "Enabled": False,
+                "IncludeCookies": False,
+                "Bucket": "",
+                "Prefix": "",
+            }
+        return response
+
+    def _distribution_response(
+        self,
+        caller_reference: str,
+        domains: List[str],
+        iam_server_certificate_id: str,
+        origin_hostname: str,
+        origin_path: str,
+        distribution_id: str,
+        distribution_hostname: str,
+        status: str = "InProgress",
+        enabled: bool = True,
+        forward_cookie_policy: str = "all",
+        forwarded_cookies: list = None,
+        forwarded_headers: list = None,
+        origin_protocol_policy: str = "https-only",
+        bucket_prefix: str = "",
+        custom_error_responses: dict = None,
+        include_le_bucket: bool = False,
+    ) -> Dict[str, Any]:
+        if forwarded_headers is None:
+            forwarded_headers = ["HOST"]
+        cookies = {"Forward": forward_cookie_policy}
+        if forward_cookie_policy == "whitelist":
+            cookies["WhitelistedNames"] = {
+                "Quantity": len(forwarded_cookies),
+                "Items": forwarded_cookies,
+            }
+        return {
+            "Distribution": {
+                "Id": distribution_id,
+                "ARN": f"arn:aws:cloudfront::000000000000:distribution/{distribution_id}",
+                "Status": status,
+                "LastModifiedTime": datetime.utcnow(),
+                "InProgressInvalidationBatches": 0,
+                "DomainName": distribution_hostname,
+                "ActiveTrustedSigners": {"Enabled": False, "Quantity": 0, "Items": []},
+                "DistributionConfig": self._distribution_config(
+                    caller_reference,
+                    domains,
+                    iam_server_certificate_id,
+                    origin_hostname,
+                    origin_path,
+                    enabled,
+                    forward_cookie_policy,
+                    forwarded_cookies,
+                    forwarded_headers,
+                    origin_protocol_policy,
+                    bucket_prefix,
+                    custom_error_responses,
+                    include_le_bucket,
+                ),
+            }
+        }
+
+
+@pytest.fixture(autouse=True)
+def cloudfront():
+    with FakeCloudFront.stubbing(real_cloudfront) as cloudfront_stubber:
+        yield cloudfront_stubber


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add function to rotate CDN certs

The CDN fixtures are more complicated than they need to be, because I took them wholesale from the external domain broker

## Security considerations

None