### PR TITLE
actually run the renewals

### DIFF
--- a/renewer/tasks/renewals.py
+++ b/renewer/tasks/renewals.py
@@ -22,7 +22,7 @@ def queue_all_tasks(route, session):
     if isinstance(route, DomainRoute):
         get_renewal_pipeline = get_domain_renewal_pipeline
     elif isinstance(route, CdnRoute):
-        get_renewal_pipeline = get_domain_renewal_pipeline
+        get_renewal_pipeline = get_cdn_renewal_pipeline
     else:
         raise NotImplementedError(
             f"Expected one of DomainRoute, CdnRoute, got {type(route)}"

--- a/renewer/tasks/renewals.py
+++ b/renewer/tasks/renewals.py
@@ -1,0 +1,74 @@
+from huey import crontab
+
+from renewer.models.cdn import CdnRoute
+from renewer.db import SessionHandler
+from renewer.models.domain import DomainRoute
+from renewer.huey import huey
+from renewer.tasks import alb, cdn, iam, letsencrypt, s3
+
+
+@huey.periodic_task(crontab(month="*", day="*", hour="12", minute="0"))
+def renew_all_certs():
+    routes = []
+    with SessionHandler() as session:
+        for Route in (CdnRoute, DomainRoute):
+            routes.extend(Route.find_active_instances(session))
+        for route in routes:
+            if route.needs_renewal:
+                queue_all_tasks(route, session)
+
+
+def queue_all_tasks(route, session):
+    if isinstance(route, DomainRoute):
+        get_renewal_pipeline = get_domain_renewal_pipeline
+    elif isinstance(route, CdnRoute):
+        get_renewal_pipeline = get_domain_renewal_pipeline
+    else:
+        raise NotImplementedError(
+            f"Expected one of DomainRoute, CdnRoute, got {type(route)}"
+        )
+    pipeline = get_renewal_pipeline(route, session)
+    huey.enqueue(pipeline)
+
+
+def get_domain_renewal_pipeline(alb_route: DomainRoute, session):
+    operation = alb_route.create_renewal_operation()
+    session.add(operation)
+    session.commit()
+    pipeline = (
+        letsencrypt.create_user.s(operation.id, alb_route.route_type)
+        .then(
+            letsencrypt.create_private_key_and_csr, operation.id, alb_route.route_type
+        )
+        .then(letsencrypt.initiate_challenges, operation.id, alb_route.route_type)
+        .then(s3.upload_challenge_files, operation.id, alb_route.route_type)
+        .then(letsencrypt.answer_challenges, operation.id, alb_route.route_type)
+        .then(letsencrypt.retrieve_certificate, operation.id, alb_route.route_type)
+        .then(iam.upload_certificate, operation.id, alb_route.route_type)
+        .then(alb.associate_certificate, operation.id, alb_route.route_type)
+        .then(alb.remove_old_certificate, operation.id, alb_route.route_type)
+        .then(alb.wait_for_cert_update, operation.id, alb_route.route_type)
+        .then(iam.delete_old_certificate)
+    )
+    return pipeline
+
+
+def get_cdn_renewal_pipeline(cdn_route: CdnRoute, session):
+    operation = cdn_route.create_renewal_operation()
+    session.add(operation)
+    session.commit()
+    pipeline = (
+        letsencrypt.create_user.s(operation.id, cdn_route.route_type)
+        .then(
+            letsencrypt.create_private_key_and_csr, operation.id, cdn_route.route_type
+        )
+        .then(letsencrypt.initiate_challenges, operation.id, cdn_route.route_type)
+        .then(s3.upload_challenge_files, operation.id, cdn_route.route_type)
+        .then(letsencrypt.answer_challenges, operation.id, cdn_route.route_type)
+        .then(letsencrypt.retrieve_certificate, operation.id, cdn_route.route_type)
+        .then(iam.upload_certificate, operation.id, cdn_route.route_type)
+        .then(cdn.associate_certificate, operation.id, cdn_route.route_type)
+        .then(cdn.wait_for_distribution, operation.id, cdn_route.route_type)
+        .then(iam.delete_old_certificate)
+    )
+    return pipeline

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from tests.lib.fake_alb import alb
 from tests.lib.fake_cloudfront import cloudfront
 from tests.lib.fake_iam import iam_commercial, iam_govcloud
 from tests.lib.fake_s3 import s3_commercial, s3_govcloud
-from tests.lib.tasks import tasks, immediate_huey
+from tests.lib.tasks import tasks, clean_huey, immediate_huey
 
 
 def pytest_configure(config):

--- a/tests/lib/alb_fixtures.py
+++ b/tests/lib/alb_fixtures.py
@@ -1,6 +1,8 @@
+from typing import List
+
 import pytest
 
-from renewer.models.domain import DomainAlbProxy, DomainRoute
+from renewer.models.domain import DomainAlbProxy, DomainRoute, DomainCertificate
 
 
 @pytest.fixture(scope="function")
@@ -16,12 +18,51 @@ def proxy(clean_db):
 
 
 @pytest.fixture(scope="function")
-def alb_route(clean_db, proxy):
-    route = DomainRoute()
-    route.instance_id = "fixture-route"
-    route.state = "provisioned"
-    route.domains = ["example.com", "www.example.com"]
-    route.alb_proxy = proxy
-    clean_db.add(route)
-    clean_db.commit()
+def alb_route(clean_db, proxy) -> DomainRoute:
+    route = make_route(
+        clean_db, proxy, "fixture_route", ["example.com", "www.example.com"]
+    )
     return route
+
+
+def make_route(
+    session,
+    proxy: DomainAlbProxy,
+    instance_id: str,
+    domains: List[str],
+    state: str = "provisioned",
+) -> DomainRoute:
+    route = DomainRoute()
+    route.instance_id = instance_id
+    route.state = state
+    route.domains = domains
+    route.alb_proxy = proxy
+    session.add(route)
+    session.commit()
+    return route
+
+
+def make_cert(
+    session,
+    route: DomainRoute,
+    expiration,
+    upload_date,
+    associate_to_route: bool = True,
+) -> DomainCertificate:
+    certificate = DomainCertificate()
+    certificate.expires = expiration
+    if associate_to_route:
+        certificate.route = route
+
+    certificate.iam_server_certificate_name = (
+        f"{route.instance_id}-{upload_date.isoformat()}-{certificate.id}"
+    )
+    certificate.iam_server_certificate_id = (
+        f"FAKE_CERT_ID-{route.instance_id}-{certificate.id}"
+    )
+    certificate.iam_server_certificate_arn = (
+        f"arn:aws:iam:1234:/alb/test/{certificate.iam_server_certificate_name}"
+    )
+    session.add(certificate)
+    session.commit()
+    return certificate

--- a/tests/lib/cdn_fixtures.py
+++ b/tests/lib/cdn_fixtures.py
@@ -1,6 +1,6 @@
 import pytest
 
-from renewer.models.cdn import CdnRoute
+from renewer.models.cdn import CdnRoute, CdnCertificate
 
 
 @pytest.fixture(scope="function")
@@ -14,3 +14,33 @@ def cdn_route(clean_db):
     clean_db.add(route)
     clean_db.commit()
     return route
+
+
+def make_route(session, instance_id: str, domains: str, state: str = "provisioned"):
+    route = CdnRoute()
+    route.instance_id = instance_id
+    route.state = state
+    route.domain_external = domains
+    session.add(route)
+    session.commit()
+    return route
+
+
+def make_cert(session, route, expiration, upload_date, associate_to_route: bool = True):
+    certificate = CdnCertificate()
+    certificate.expires = expiration
+    if associate_to_route:
+        certificate.route = route
+
+    certificate.iam_server_certificate_name = (
+        f"{route.instance_id}-{upload_date.isoformat()}-{certificate.id}"
+    )
+    certificate.iam_server_certificate_id = (
+        f"FAKE_CERT_ID-{route.instance_id}-{certificate.id}"
+    )
+    certificate.iam_server_certificate_arn = (
+        f"arn:aws:iam:1234:/alb/test/{certificate.iam_server_certificate_name}"
+    )
+    session.add(certificate)
+    session.commit()
+    return certificate


### PR DESCRIPTION
## Changes proposed in this pull request:

- create a task to actually run the renewals (note they won't run yet since we haven't imported this file into the consumer)
- refactor tests to use new fixtures


## Security considerations

None