### PR TITLE
add route_type to alb and cdn functions

### DIFF
--- a/tests/integration/test_alb_renewal.py
+++ b/tests/integration/test_alb_renewal.py
@@ -240,7 +240,7 @@ def test_associate_cert(clean_db, alb_route: DomainRoute, immediate_huey, alb):
         "arn:aws:listener:1234", certificate.iam_server_certificate_arn
     )
 
-    alb_tasks.associate_certificate(operation.id)
+    alb_tasks.associate_certificate(operation.id, alb_route.route_type)
 
     clean_db.expunge_all()
 
@@ -265,9 +265,9 @@ def test_remove_old_cert(clean_db, alb_route: DomainRoute, immediate_huey, alb):
         "arn:aws:listener:1234", old_certificate.iam_server_certificate_arn
     )
 
-    alb_tasks.remove_old_certificate(operation.id)
+    alb_tasks.remove_old_certificate(operation.id, alb_route.route_type)
     # run it twice, to make sure a retry won't nuke the good cert
-    alb_tasks.remove_old_certificate(operation.id)
+    alb_tasks.remove_old_certificate(operation.id, alb_route.route_type)
 
     clean_db.expunge_all()
 

--- a/tests/integration/test_cdn_renewal.py
+++ b/tests/integration/test_cdn_renewal.py
@@ -260,7 +260,7 @@ def test_associate_cert(clean_db, cdn_route: CdnRoute, immediate_huey, cloudfron
         bucket_prefix="4321/",
     )
 
-    cdn.associate_certificate(operation.id)
+    cdn.associate_certificate(operation.id, cdn_route.route_type)
 
     clean_db.expunge_all()
 
@@ -293,7 +293,7 @@ def test_waits_for_update_to_finish_updating(
     # what we're really testing.
     # this test just makes sure we call get_distribution until it's Deployed
     # and that nothing blows up
-    cdn.wait_for_distribution(operation.id)
+    cdn.wait_for_distribution(operation.id, cdn_route.route_type)
 
 
 def test_delete_old_certificate(


### PR DESCRIPTION
adding route type to these functions lets all the huey tasks have the same signature.

## Changes proposed in this pull request:

- add route_type to all tasks
- check route_type on type-specific tasks


## Security considerations

None