### PR TITLE
handle none cases for certificate metadata

### DIFF
--- a/migrations/versions/95e3ab2a28dd_stop_using_arn_and_name.py
+++ b/migrations/versions/95e3ab2a28dd_stop_using_arn_and_name.py
@@ -1,0 +1,71 @@
+"""stop using arn and name
+
+Revision ID: 95e3ab2a28dd
+Revises: 23319464f990
+Create Date: 2021-10-05 23:42:27.009229
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.declarative import declarative_base
+
+
+# revision identifiers, used by Alembic.
+revision = "95e3ab2a28dd"
+down_revision = "23319464f990"
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+
+
+class DomainCertificate(Base):
+    __tablename__ = "certificates"
+
+    id = sa.Column(sa.Integer, sa.Sequence("certificates_id_seq"), primary_key=True)
+    arn = sa.Column(sa.Text)
+    name = sa.Column(sa.Text)
+    iam_server_certificate_name = sa.Column(sa.Text)
+    iam_server_certificate_arn = sa.Column(sa.Text)
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+def upgrade_cdn():
+    pass
+
+
+def downgrade_cdn():
+    pass
+
+
+def upgrade_domain():
+    """
+    cdn-broker's db didn't previously track arns, names, or IDs, so I added them to the cdn-broker db and to
+    the domain-broker db. When I did that, I created new columns, instead of updating the mappings
+    to point to the existing columns. This shoves all the data from before into the new columns,
+    because that feels easier to reason about than dropping the new ones and aliasing the new names
+    to the old columns.
+    """
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    for certificate in session.query(DomainCertificate):
+        if certificate.arn is not None:
+            certificate.iam_server_certificate_arn = certificate.arn
+            session.add(certificate)
+        if certificate.name is not None:
+            certificate.iam_server_certificate_name = certificate.name
+            session.add(certificate)
+    session.commit()
+
+
+def downgrade_domain():
+    pass

--- a/renewer/models/domain.py
+++ b/renewer/models/domain.py
@@ -91,7 +91,9 @@ class DomainRoute(DomainModel, RouteModel):
                 if self.instance_id in cert["CertificateArn"]:
                     arn = cert["CertificateArn"]
 
-                    if any(c.arn == arn for c in self.certificates):
+                    if any(
+                        c.iam_server_certificate_arn == arn for c in self.certificates
+                    ):
                         # we already know about this one
                         continue
 
@@ -117,8 +119,6 @@ class DomainCertificate(DomainModel, CertificateModel):
     # certificate is the actual body of the certificate chain
     # this was used by the old broker, but the renewer uses fullchain_pem and leaf_pem instead
     certificate = sa.Column(postgresql.BYTEA)
-    arn = sa.Column(sa.Text)
-    name = sa.Column(sa.Text)
     expires = sa.Column(postgresql.TIMESTAMP, index=True)
     private_key_pem: str = sa.Column(
         StringEncryptedType(sa.Text, db_encryption_key, AesGcmEngine, "pkcs5")
@@ -144,9 +144,9 @@ class DomainCertificate(DomainModel, CertificateModel):
         cert = DomainCertificate()
         cert.route = route
         cert.created_at = datetime.datetime.now()
-        cert.arn = arn
+        cert.iam_server_certificate_arn = arn
         cert.expires = expires
-        cert.name = name
+        cert.iam_server_certificate_name = name
 
         return cert
 

--- a/renewer/tasks/alb.py
+++ b/renewer/tasks/alb.py
@@ -52,6 +52,16 @@ def remove_old_certificate(session, operation_id: int, route_type: RouteType):
             "message": f"removing certificate on alb proxy {route_alb.listener_arn}. Old certificate id: {old_certificate.id}",
         },
     )
+    if old_certificate.iam_server_certificate_arn is None:
+        json_log(
+            logger.warning,
+            {
+                "instance_id": route.instance_id,
+                "message": "skipping certificate without known arn",
+                "certificate_id": old_certificate.id,
+            },
+        )
+        return
 
     if (
         old_certificate.iam_server_certificate_arn

--- a/renewer/tasks/iam.py
+++ b/renewer/tasks/iam.py
@@ -109,6 +109,17 @@ def delete_old_certificate(session, operation_id: int, instance_type: RouteType)
         },
     )
 
+    if old_certificate.iam_server_certificate_name is None:
+        json_log(
+            logger.warning,
+            {
+                "instance_id": route.instance_id,
+                "message": "not deleting certificate with unknown name",
+                "certificate_id": old_certificate.id,
+            },
+        )
+        return
+
     try:
         iam.delete_server_certificate(
             ServerCertificateName=old_certificate.iam_server_certificate_name

--- a/tests/integration/test_alb_backport.py
+++ b/tests/integration/test_alb_backport.py
@@ -19,7 +19,7 @@ def test_backport_all_certs(clean_db, alb, iam_govcloud, immediate_huey):
     old_cert = DomainCertificate()
     old_cert.route = route
     old_cert.expires = datetime(year=2021, month=2, day=1, hour=0, minute=0, second=0)
-    old_cert.arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
+    old_cert.iam_server_certificate_arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
     clean_db.add(proxy)
     clean_db.add(route)
     clean_db.add(old_cert)
@@ -46,11 +46,11 @@ def test_backport_all_certs(clean_db, alb, iam_govcloud, immediate_huey):
     route = clean_db.query(DomainRoute).filter_by(instance_id="renew-me").first()
     cert = route.certificates[0]
     assert (
-        cert.arn
+        cert.iam_server_certificate_arn
         == "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-03-12_12-34-12"
     )
     assert cert.expires is not None
-    assert cert.name == "cf-domains-renew-me-2021-03-12_12-34-12"
+    assert cert.iam_server_certificate_name == "cf-domains-renew-me-2021-03-12_12-34-12"
 
 
 def test_no_error_when_no_backport(clean_db, alb, iam_govcloud, immediate_huey):
@@ -66,7 +66,7 @@ def test_no_error_when_no_backport(clean_db, alb, iam_govcloud, immediate_huey):
     old_cert = DomainCertificate()
     old_cert.route = route
     old_cert.expires = datetime(year=2021, month=2, day=1, hour=0, minute=0, second=0)
-    old_cert.arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
+    old_cert.iam_server_certificate_arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
     clean_db.add(proxy)
     clean_db.add(route)
     clean_db.add(old_cert)

--- a/tests/unit/test_alb_db.py
+++ b/tests/unit/test_alb_db.py
@@ -159,11 +159,11 @@ def test_backport_from_manual_renewal(clean_db, alb, iam_govcloud):
     route = clean_db.query(DomainRoute).filter_by(instance_id="renew-me").first()
     cert = route.certificates[0]
     assert (
-        cert.arn
+        cert.iam_server_certificate_arn
         == "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-03-12_12-34-12"
     )
     assert cert.expires is not None
-    assert cert.name == "cf-domains-renew-me-2021-03-12_12-34-12"
+    assert cert.iam_server_certificate_name == "cf-domains-renew-me-2021-03-12_12-34-12"
 
 
 def test_backport_from_manual_renewal_ignores_existing(clean_db, alb, iam_govcloud):
@@ -179,8 +179,8 @@ def test_backport_from_manual_renewal_ignores_existing(clean_db, alb, iam_govclo
     old_cert = DomainCertificate()
     old_cert.route = route
     old_cert.expires = datetime(year=2021, month=2, day=1, hour=0, minute=0, second=0)
-    old_cert.arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
-    old_cert.name = "cf-domains-renew-me-2021-01-01_12-34-56"
+    old_cert.iam_server_certificate_arn = "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
+    old_cert.iam_server_certificate_name = "cf-domains-renew-me-2021-01-01_12-34-56"
     clean_db.add(proxy)
     clean_db.add(route)
     clean_db.add(old_cert)
@@ -200,11 +200,11 @@ def test_backport_from_manual_renewal_ignores_existing(clean_db, alb, iam_govclo
     route = clean_db.query(DomainRoute).filter_by(instance_id="renew-me").first()
     cert = route.certificates[0]
     assert (
-        cert.arn
+        cert.iam_server_certificate_arn
         == "arn:aws:iam:1234:server-certificate/domains/local/cf-domains-renew-me-2021-01-01_12-34-56"
     )
     assert cert.expires is not None
-    assert cert.name == "cf-domains-renew-me-2021-01-01_12-34-56"
+    assert cert.iam_server_certificate_name == "cf-domains-renew-me-2021-01-01_12-34-56"
 
 
 def test_stores_acmeuser_private_key_pem_encrypted(clean_db):


### PR DESCRIPTION


## Changes proposed in this pull request:

- handle missing cert data better
- add backport to make there be less missing certificate data
- drop name and arn from domain certificate model (but not database!) to force using only one

## Security considerations

None