### PR TITLE
fix edge case on duplicate certificate upload

### DIFF
--- a/tests/integration/test_cdn_renewal.py
+++ b/tests/integration/test_cdn_renewal.py
@@ -223,6 +223,71 @@ def test_upload_cert_to_iam(
     assert certificate.iam_server_certificate_arn.startswith("arn:aws:iam")
 
 
+def test_upload_cert_to_iam_a_second_time(
+    clean_db, cdn_route: CdnRoute, immediate_huey, iam_commercial
+):
+
+    operation = cdn_route.create_renewal_operation()
+    certificate = CdnCertificate()
+    operation.certificate = certificate
+
+    certificate.fullchain_pem = """
+    -----BEGIN CERTIFICATE-----
+    look! a leaf cert!
+    these are longer in reality though
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    look! an intermediate cert!
+    these are longer in reality though
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    look! a CA cert!
+    these are longer in reality though
+    -----END CERTIFICATE-----
+    """
+    certificate.leaf_pem = """
+    -----BEGIN CERTIFICATE-----
+    look! a leaf cert!
+    these are longer in reality though
+    -----END CERTIFICATE-----
+    """
+    certificate.private_key_pem = """
+    -----BEGIN PRIVATE KEY-----
+    don't look! a private key!
+    these are longer in reality though
+    -----END PRIVATE KEY-----
+    """
+
+    clean_db.add_all([operation, cdn_route, certificate])
+    clean_db.commit()
+    today = date.today().isoformat()
+    operation_id = operation.id
+
+    iam_commercial.expect_upload_server_certificate_raising_duplicate(
+        name=f"{cdn_route.instance_id}-{today}-{certificate.id}",
+        cert=certificate.leaf_pem,
+        private_key=certificate.private_key_pem,
+        chain=certificate.fullchain_pem,
+        path="/cloudfront/test/",
+    )
+    iam_commercial.expect_get_server_certificate(
+        name=f"{cdn_route.instance_id}-{today}-{certificate.id}",
+        expiration=datetime.now() + timedelta(days=90),
+        path="/cloudfront/test/",
+    )
+    clean_db.expunge_all()
+
+    iam.upload_certificate(operation_id, cdn_route.route_type)
+    operation = clean_db.query(CdnOperation).get(operation_id)
+    certificate = operation.certificate
+    assert certificate.iam_server_certificate_name
+    assert certificate.iam_server_certificate_name.startswith(cdn_route.instance_id)
+    assert certificate.iam_server_certificate_id
+    assert certificate.iam_server_certificate_id == "this-needs-to-be-sixteen-digits"
+    assert certificate.iam_server_certificate_arn
+    assert certificate.iam_server_certificate_arn.startswith("arn:aws:iam")
+
+
 def test_associate_cert(clean_db, cdn_route: CdnRoute, immediate_huey, cloudfront):
     operation = cdn_route.create_renewal_operation()
     certificate = CdnCertificate()


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix edge case on duplicate certificate upload. I collapsed the simpler case (we uploaded and somehow had the metadata) into the harder case (we uploaded and didn't catch the metadata) because it meant fewer code paths to follow, and the extra call to IAM isn't that expensive.

## Security considerations

None