### PR TITLE
dropped mypy version to keep compatibility with the code in alb.py

### DIFF
--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -100,7 +100,7 @@ marshmallow==3.13.0
     # via
     #   -r pip-tools/../requirements.txt
     #   environs
-mypy==0.910
+mypy
     # via
     #   -r pip-tools/dev-requirements.in
     #   sqlalchemy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
## Changes proposed in this pull request:

- The mypy static checker was using an old version that won't work with the current code
- I dropped off the version so it pulled in the current version
- I also modified the toml file to include python 3.9

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None