### PR TITLE
reverted empty argument and updated tests for add_listener_certificates

### DIFF
--- a/renewer/tasks/alb.py
+++ b/renewer/tasks/alb.py
@@ -33,7 +33,7 @@ def associate_certificate(session, operation_id: int, route_type: RouteType):
 
     alb.add_listener_certificates(
         ListenerArn=route_alb.listener_arn,
-        Certificates=[{"CertificateArn": certificate.iam_server_certificate_arn}, ],
+        Certificates=[{"CertificateArn": certificate.iam_server_certificate_arn}],
     )
 
 

--- a/tests/lib/fake_alb.py
+++ b/tests/lib/fake_alb.py
@@ -9,12 +9,12 @@ class FakeALB(FakeAWS):
     def expect_get_certificates_for_listener(
         self, listener_arn, num_certificates=0, add_cert_arn=None
     ):
-        certificates = [{"CertificateArn": "certificate-arn", "IsDefault": True}]
+        certificates = [{"CertificateArn": "certificate-arn"}]
         if add_cert_arn is not None:
-            certificates.append({"CertificateArn": add_cert_arn, "IsDefault": False})
+            certificates.append({"CertificateArn": add_cert_arn})
         for i in range(num_certificates):
             certificates.append(
-                {"CertificateArn": f"certificate-arn-{i}", "IsDefault": False}
+                {"CertificateArn": f"certificate-arn-{i}"}
             )
         self.stubber.add_response(
             "describe_listener_certificates",
@@ -27,8 +27,8 @@ class FakeALB(FakeAWS):
             "add_listener_certificates",
             {
                 "Certificates": [
-                    {"CertificateArn": "arn:2", "IsDefault": True},
-                    {"CertificateArn": iam_cert_arn, "IsDefault": False},
+                    {"CertificateArn": "arn:2"},
+                    {"CertificateArn": iam_cert_arn},
                 ]
             },
             {


### PR DESCRIPTION
## Changes proposed in this pull request:

- updated tests to remove isDefault as it's not needed
- removed empty arg

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None