### PR TITLE
Bump versions, silence deprecations

### DIFF
--- a/dev
+++ b/dev
@@ -34,6 +34,10 @@ main() {
       build_image
       run "$@"
       ;;
+    upgrade-requirements)
+      build_image
+      upgrade-requirements "$@"
+      ;;
     update-requirements)
       build_image
       update-requirements "$@"
@@ -115,6 +119,10 @@ update-requirements() {
   run "docker/update-requirements-txt"
 }
 
+upgrade-requirements() {
+  run "docker/upgrade-requirements-txt"
+}
+
 new-migration() {
   [[ "$#" -eq 1 ]] || usage "Missing migration description (e.g. 'added foo table')"
   run "./docker/start-servers.sh && alembic -c migrations/alembic.ini upgrade head && alembic -c migrations/alembic.ini revision --autogenerate -m \"$1\""
@@ -152,7 +160,13 @@ usage() {
 
     # Generate the pip-tools/*requirements.txt files from
     # pip-tools/*requirements.in
+    # without upgrading existing dependencies
     $me update-requirements
+
+    # Generate the pip-tools/*requirements.txt files from
+    # pip-tools/*requirements.in
+    # upgrading all packages to the latest allowed by their spec
+    $me upgrade-requirements
 
     # Run command 'foo' in the container
     $me run foo

--- a/docker/tests
+++ b/docker/tests
@@ -9,9 +9,9 @@ alembic -c migrations/alembic.ini upgrade head
 
 if [[ "$#" -ge 1 ]] && [[ "$1" == "watch" ]]; then
   shift
-  ptw --spool=1000 -n -c -w -- -Werror -vv "$@"
+  ptw --spool=1000 -n -c -w -- "$@"
 else
-  python -m pytest -Werror -vv "$@"
+  SQLALCHEMY_WARN_20=1 python -m pytest "$@"
 fi
 
 ./docker/stop-servers.sh

--- a/docker/upgrade-requirements-txt
+++ b/docker/upgrade-requirements-txt
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export CUSTOM_COMPILE_COMMAND="./dev update-requirements"
+echo "Installing latest piptools"
+pip install pip-tools
+echo "Compiling requirements.txt"
+python -m piptools compile \
+  --quiet \
+  --strip-extras \
+  --upgrade \
+  --output-file=requirements.txt \
+  pip-tools/requirements.in
+
+echo "Compiling dev-requirements.txt"
+python -m piptools compile \
+  --quiet \
+  --strip-extras \
+  --upgrade \
+  --output-file=pip-tools/dev-requirements.txt \
+  pip-tools/dev-requirements.in

--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -4,113 +4,113 @@
 #
 #    ./dev update-requirements
 #
-acme==1.18.0
+acme==2.10.0
     # via -r pip-tools/../requirements.txt
-alembic==1.6.5
+alembic==1.13.1
     # via -r pip-tools/../requirements.txt
-appdirs==1.4.4
-    # via black
-attrs==21.2.0
-    # via pytest
-black==21.7b0
+async-timeout==4.0.3
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   redis
+black==24.4.2
     # via -r pip-tools/dev-requirements.in
-boto3==1.34.39
+boto3==1.34.118
     # via -r pip-tools/../requirements.txt
-boto3-stubs==1.34.39
+boto3-stubs==1.34.118
     # via -r pip-tools/dev-requirements.in
-botocore==1.34.39
+botocore==1.34.118
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.37
+botocore-stubs==1.34.94
     # via boto3-stubs
-build==1.0.3
+build==1.2.1
     # via pip-tools
-certifi==2021.5.30
+certifi==2024.6.2
     # via
     #   -r pip-tools/../requirements.txt
     #   requests
 cfenv==0.5.3
     # via -r pip-tools/../requirements.txt
-cffi==1.14.6
+cffi==1.16.0
     # via
     #   -r pip-tools/../requirements.txt
     #   cryptography
-chardet==4.0.0
-    # via
-    #   -r pip-tools/../requirements.txt
-    #   acme
-charset-normalizer==2.0.4
+charset-normalizer==3.3.2
     # via
     #   -r pip-tools/../requirements.txt
     #   requests
-click==8.0.1
+click==8.1.7
     # via
     #   black
     #   pip-tools
-colorama==0.4.4
+colorama==0.4.6
     # via pytest-watch
-cryptography==3.4.8
+cryptography==42.0.7
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
     #   josepy
     #   pyopenssl
+    #   types-pyopenssl
+    #   types-redis
 docopt==0.6.2
     # via pytest-watch
-environs==9.3.3
+environs==11.0.0
     # via -r pip-tools/../requirements.txt
-furl==2.1.2
+exceptiongroup==1.2.1
+    # via pytest
+furl==2.1.3
     # via
     #   -r pip-tools/../requirements.txt
     #   cfenv
-greenlet==1.1.1
+greenlet==3.0.3
     # via
     #   -r pip-tools/../requirements.txt
     #   sqlalchemy
-huey==2.4.0
+huey==2.5.0
     # via -r pip-tools/../requirements.txt
-idna==3.2
+idna==3.7
     # via
     #   -r pip-tools/../requirements.txt
     #   requests
-importlib-metadata==7.0.1
+importlib-metadata==7.1.0
     # via build
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-jmespath==0.10.0
+jmespath==1.0.1
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
     #   botocore
-josepy==1.8.0
+josepy==1.14.0
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
-mako==1.1.5
+mako==1.3.5
     # via
     #   -r pip-tools/../requirements.txt
     #   alembic
-markupsafe==2.0.1
+markupsafe==2.1.5
     # via
     #   -r pip-tools/../requirements.txt
     #   mako
-marshmallow==3.13.0
+marshmallow==3.21.2
     # via
     #   -r pip-tools/../requirements.txt
     #   environs
-mypy==0.910
+mypy==1.10.0
     # via
     #   -r pip-tools/dev-requirements.in
     #   sqlalchemy
-mypy-boto3-cloudfront==1.34.0
+mypy-boto3-cloudfront==1.34.110
     # via boto3-stubs
-mypy-boto3-elbv2==1.34.32
+mypy-boto3-elbv2==1.34.108
     # via boto3-stubs
-mypy-boto3-iam==1.34.8
+mypy-boto3-iam==1.34.83
     # via boto3-stubs
-mypy-extensions==0.4.4
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
@@ -118,75 +118,66 @@ orderedmultidict==1.0.1
     # via
     #   -r pip-tools/../requirements.txt
     #   furl
-packaging==21.0
+packaging==24.0
     # via
+    #   -r pip-tools/../requirements.txt
+    #   black
     #   build
+    #   marshmallow
     #   pytest
-pathspec==0.9.0
+pathspec==0.12.1
     # via black
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via -r pip-tools/dev-requirements.in
-pluggy==0.13.1
+platformdirs==4.2.2
+    # via black
+pluggy==1.5.0
     # via pytest
-psycopg2==2.9.1
+psycopg2==2.9.9
     # via -r pip-tools/../requirements.txt
-py==1.10.0
-    # via pytest
-pycparser==2.20
+pycparser==2.22
     # via
     #   -r pip-tools/../requirements.txt
     #   cffi
-pyopenssl==20.0.1
+pyopenssl==24.1.0
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
     #   josepy
-pyparsing==2.4.7
-    # via packaging
-pyproject-hooks==1.0.0
-    # via build
+pyproject-hooks==1.1.0
+    # via
+    #   build
+    #   pip-tools
 pyrfc3339==1.1
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
-pytest==6.2.4
+pytest==8.2.1
     # via
     #   -r pip-tools/dev-requirements.in
     #   pytest-watch
 pytest-watch==4.2.0
     # via -r pip-tools/dev-requirements.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r pip-tools/../requirements.txt
-    #   alembic
     #   botocore
-python-dotenv==0.19.0
+python-dotenv==1.0.1
     # via
     #   -r pip-tools/../requirements.txt
     #   environs
-python-editor==1.0.4
-    # via
-    #   -r pip-tools/../requirements.txt
-    #   alembic
-pytz==2021.1
+pytz==2024.1
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
     #   pyrfc3339
-redis==3.5.3
+redis==5.0.4
     # via -r pip-tools/../requirements.txt
-regex==2021.8.3
-    # via black
-requests==2.26.0
+requests==2.32.3
     # via
     #   -r pip-tools/../requirements.txt
     #   acme
-    #   requests-toolbelt
-requests-toolbelt==0.9.1
-    # via
-    #   -r pip-tools/../requirements.txt
-    #   acme
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via
     #   -r pip-tools/../requirements.txt
     #   boto3
@@ -195,58 +186,59 @@ six==1.16.0
     #   -r pip-tools/../requirements.txt
     #   furl
     #   orderedmultidict
-    #   pyopenssl
     #   python-dateutil
-    #   sqlalchemy-utils
-sqlalchemy==1.4.23
+sqlalchemy==1.4.52
     # via
     #   -r pip-tools/../requirements.txt
     #   -r pip-tools/dev-requirements.in
     #   alembic
     #   sqlalchemy-utils
-sqlalchemy-utils==0.37.8
+sqlalchemy-utils==0.41.2
     # via -r pip-tools/../requirements.txt
-sqlalchemy2-stubs==0.0.2a15
+sqlalchemy2-stubs==0.0.2a38
     # via sqlalchemy
-toml==0.10.2
-    # via
-    #   mypy
-    #   pytest
-tomli==1.2.1
+tomli==2.0.1
     # via
     #   black
     #   build
+    #   mypy
     #   pip-tools
-    #   pyproject-hooks
-types-awscrt==0.20.3
+    #   pytest
+types-awscrt==0.20.9
     # via botocore-stubs
-types-cryptography==3.3.5
+types-cffi==1.16.0.20240331
     # via types-pyopenssl
-types-enum34==1.1.0
-    # via types-cryptography
-types-ipaddress==1.0.0
-    # via types-cryptography
-types-pyopenssl==20.0.1
-    # via -r pip-tools/dev-requirements.in
-types-redis==3.5.8
-    # via -r pip-tools/dev-requirements.in
-typing-extensions==4.9.0
+types-pyopenssl==24.1.0.20240425
     # via
+    #   -r pip-tools/dev-requirements.in
+    #   types-redis
+types-redis==4.6.0.20240425
+    # via -r pip-tools/dev-requirements.in
+types-s3transfer==0.10.1
+    # via boto3-stubs
+types-setuptools==70.0.0.20240524
+    # via types-cffi
+typing-extensions==4.12.1
+    # via
+    #   -r pip-tools/../requirements.txt
+    #   alembic
+    #   black
+    #   boto3-stubs
     #   mypy
     #   mypy-boto3-cloudfront
     #   mypy-boto3-elbv2
     #   mypy-boto3-iam
     #   sqlalchemy2-stubs
-urllib3==1.26.6
+urllib3==1.26.18
     # via
     #   -r pip-tools/../requirements.txt
     #   botocore
     #   requests
-watchdog==2.1.3
+watchdog==4.0.1
     # via pytest-watch
-wheel==0.37.0
+wheel==0.43.0
     # via pip-tools
-zipp==3.17.0
+zipp==3.19.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pip-tools/requirements.in
+++ b/pip-tools/requirements.in
@@ -7,5 +7,5 @@ environs
 huey
 psycopg2
 redis
-sqlalchemy
+sqlalchemy<2
 sqlalchemy-utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,16 @@ exclude = '''
 [tool.mypy]
 plugins = ['sqlalchemy.ext.mypy.plugin']
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = ["-vv"]
+filterwarnings = [
+  'error',
+  # this is an issue with the ACME library - need to wait on them for a fix
+  'ignore:X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.:DeprecationWarning',
+  # sqlalchemy upgrade warnings - we should be working through these
+  'ignore:Using plain strings to indicate SQL statements without using the text.*:sqlalchemy.exc.RemovedIn20Warning',
+  'ignore:Passing bind arguments to Session.execute.*:sqlalchemy.exc.RemovedIn20Warning',
+  'ignore:"[azA-Z]+" object is being merged into a Session along the backref cascade path for relationship .*:sqlalchemy.exc.RemovedIn20Warning',
+  'ignore:The Query.get\(\) method is considered legacy as of the 1.x series of SQLAlchemy and becomes a legacy construct in 2.0.*:sqlalchemy.exc.LegacyAPIWarning',
+]

--- a/renewer/models/cdn.py
+++ b/renewer/models/cdn.py
@@ -33,7 +33,7 @@ convention = {
 
 metadata = sa.MetaData(naming_convention=convention)
 
-CdnModel = declarative.declarative_base(metadata=metadata)
+CdnModel = orm.declarative_base(metadata=metadata)
 
 
 def db_encryption_key():
@@ -171,7 +171,7 @@ class CdnAcmeUserV2(CdnModel, AcmeUserV2Model):
     )
     registration_json = sa.Column(sa.Text)
 
-    routes: List[CdnRoute] = orm.relation(
+    routes: List[CdnRoute] = orm.relationship(
         "CdnRoute",
         backref="acme_user",
         primaryjoin="(foreign(CdnRoute.acme_user_id)) == CdnAcmeUserV2.id",

--- a/renewer/models/domain.py
+++ b/renewer/models/domain.py
@@ -32,7 +32,7 @@ convention = {
 }
 
 metadata = sa.MetaData(naming_convention=convention)
-DomainModel = declarative.declarative_base(metadata=metadata)
+DomainModel = orm.declarative_base(metadata=metadata)
 
 
 def db_encryption_key():
@@ -200,7 +200,7 @@ class DomainAcmeUserV2(DomainModel, AcmeUserV2Model):
     )
     registration_json = sa.Column(sa.Text)
 
-    routes: List[DomainRoute] = orm.relation(
+    routes: List[DomainRoute] = orm.relationship(
         "DomainRoute",
         backref="acme_user",
         primaryjoin="(foreign(DomainRoute.acme_user_id)) == DomainAcmeUserV2.id",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,103 +4,97 @@
 #
 #    ./dev update-requirements
 #
-acme==1.18.0
+acme==2.10.0
     # via -r pip-tools/requirements.in
-alembic==1.6.5
+alembic==1.13.1
     # via -r pip-tools/requirements.in
-boto3==1.34.39
+async-timeout==4.0.3
+    # via redis
+boto3==1.34.118
     # via -r pip-tools/requirements.in
-botocore==1.34.39
+botocore==1.34.118
     # via
     #   boto3
     #   s3transfer
-certifi==2021.5.30
+certifi==2024.6.2
     # via requests
 cfenv==0.5.3
     # via -r pip-tools/requirements.in
-cffi==1.14.6
+cffi==1.16.0
     # via cryptography
-chardet==4.0.0
-    # via acme
-charset-normalizer==2.0.4
+charset-normalizer==3.3.2
     # via requests
-cryptography==3.4.8
+cryptography==42.0.7
     # via
     #   -r pip-tools/requirements.in
     #   acme
     #   josepy
     #   pyopenssl
-environs==9.3.3
+environs==11.0.0
     # via -r pip-tools/requirements.in
-furl==2.1.2
+furl==2.1.3
     # via cfenv
-greenlet==1.1.1
+greenlet==3.0.3
     # via sqlalchemy
-huey==2.4.0
+huey==2.5.0
     # via -r pip-tools/requirements.in
-idna==3.2
+idna==3.7
     # via requests
-jmespath==0.10.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-josepy==1.8.0
+josepy==1.14.0
     # via acme
-mako==1.1.5
+mako==1.3.5
     # via alembic
-markupsafe==2.0.1
+markupsafe==2.1.5
     # via mako
-marshmallow==3.13.0
+marshmallow==3.21.2
     # via environs
 orderedmultidict==1.0.1
     # via furl
-psycopg2==2.9.1
+packaging==24.0
+    # via marshmallow
+psycopg2==2.9.9
     # via -r pip-tools/requirements.in
-pycparser==2.20
+pycparser==2.22
     # via cffi
-pyopenssl==20.0.1
+pyopenssl==24.1.0
     # via
     #   acme
     #   josepy
 pyrfc3339==1.1
     # via acme
-python-dateutil==2.8.2
-    # via
-    #   alembic
-    #   botocore
-python-dotenv==0.19.0
+python-dateutil==2.9.0.post0
+    # via botocore
+python-dotenv==1.0.1
     # via environs
-python-editor==1.0.4
-    # via alembic
-pytz==2021.1
+pytz==2024.1
     # via
     #   acme
     #   pyrfc3339
-redis==3.5.3
+redis==5.0.4
     # via -r pip-tools/requirements.in
-requests==2.26.0
-    # via
-    #   acme
-    #   requests-toolbelt
-requests-toolbelt==0.9.1
+requests==2.32.3
     # via acme
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
 six==1.16.0
     # via
     #   furl
     #   orderedmultidict
-    #   pyopenssl
     #   python-dateutil
-    #   sqlalchemy-utils
-sqlalchemy==1.4.23
+sqlalchemy==1.4.52
     # via
     #   -r pip-tools/requirements.in
     #   alembic
     #   sqlalchemy-utils
-sqlalchemy-utils==0.37.8
+sqlalchemy-utils==0.41.2
     # via -r pip-tools/requirements.in
-urllib3==1.26.6
+typing-extensions==4.12.1
+    # via alembic
+urllib3==1.26.18
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
## warnings + plan

- this breaks `./dev watch-tests` because the watcher library doesn't get toml. I'll follow up with a PR to move to the other pytest watcher later
- my plan is to work through the sqlalchemy warnings one at a time, to help lower the change size going forward

## Changes proposed in this pull request:

- add function to upgrade dependencies
- upgrade dependencies
- fix one `sqlalchemy` deprecation warning (`sqlalchemy.orm.relation` -> `sqlalchemy.orm.relationship`)
- silence other `sqlalchemy` deprecation warnings

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

addresses some dependency warnings that dependabot is shouting about.