### PR TITLE
switch to pytest-watcher

### DIFF
--- a/docker/tests
+++ b/docker/tests
@@ -9,7 +9,7 @@ alembic -c migrations/alembic.ini upgrade head
 
 if [[ "$#" -ge 1 ]] && [[ "$1" == "watch" ]]; then
   shift
-  ptw --spool=1000 -n -c -w -- "$@"
+  SQLALCHEMY_WARN_20=1 ptw . "$@"
 else
   SQLALCHEMY_WARN_20=1 python -m pytest "$@"
 fi

--- a/pip-tools/dev-requirements.in
+++ b/pip-tools/dev-requirements.in
@@ -4,7 +4,7 @@ boto3-stubs[iam,cloudfront,elbv2]
 mypy
 pip-tools
 pytest
-pytest-watch
+pytest-watcher
 sqlalchemy[mypy]
 types-pyOpenSSL
 types-redis

--- a/pip-tools/dev-requirements.txt
+++ b/pip-tools/dev-requirements.txt
@@ -45,8 +45,6 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-colorama==0.4.6
-    # via pytest-watch
 cryptography==42.0.7
     # via
     #   -r pip-tools/../requirements.txt
@@ -55,8 +53,6 @@ cryptography==42.0.7
     #   pyopenssl
     #   types-pyopenssl
     #   types-redis
-docopt==0.6.2
-    # via pytest-watch
 environs==11.0.0
     # via -r pip-tools/../requirements.txt
 exceptiongroup==1.2.1
@@ -153,10 +149,8 @@ pyrfc3339==1.1
     #   -r pip-tools/../requirements.txt
     #   acme
 pytest==8.2.1
-    # via
-    #   -r pip-tools/dev-requirements.in
-    #   pytest-watch
-pytest-watch==4.2.0
+    # via -r pip-tools/dev-requirements.in
+pytest-watcher==0.4.2
     # via -r pip-tools/dev-requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -204,6 +198,7 @@ tomli==2.0.1
     #   mypy
     #   pip-tools
     #   pytest
+    #   pytest-watcher
 types-awscrt==0.20.9
     # via botocore-stubs
 types-cffi==1.16.0.20240331
@@ -235,7 +230,7 @@ urllib3==1.26.18
     #   botocore
     #   requests
 watchdog==4.0.1
-    # via pytest-watch
+    # via pytest-watcher
 wheel==0.43.0
     # via pip-tools
 zipp==3.19.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,15 @@ exclude = '''
 )/
 '''
 
+[tool.pytest-watcher]
+now = true
+clear = true
+delay = 0.2
+runner = "pytest"
+runner_args = []
+patterns = ["renewer/*.py", "tests/*.py"]
+ignore_patterns = ["venv/*", ".venv/*"]
+
 [tool.mypy]
 plugins = ['sqlalchemy.ext.mypy.plugin']
 ignore_missing_imports = true


### PR DESCRIPTION

## Changes proposed in this pull request:

- switch to pytest-watcher


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None  - these changes only affect local unit testing