### PR TITLE
Removing set pipeline reference to varz file since secrets are in credhub

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -47,8 +47,6 @@ jobs:
     trigger: true
   - set_pipeline: self
     file: src/ci/pipeline.yml
-    var_files:
-    - secrets/((name)).yml
 
 - name: test
   plan:


### PR DESCRIPTION

## Changes proposed in this pull request:

- Remove var hook as it's no longer needed with secrets in credhub


## Security considerations

n/a
