### PR TITLE
update tasks to use hardened images

### DIFF
--- a/ci/stop-apps.yml
+++ b/ci/stop-apps.yml
@@ -1,9 +1,13 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: 18fgsa/concourse-task
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 inputs:
 - name: src

--- a/ci/upgrade-schema.yml
+++ b/ci/upgrade-schema.yml
@@ -1,9 +1,13 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: 18fgsa/concourse-task
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 inputs:
 - name: src


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update task files to use hardened images

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Use hardened images
